### PR TITLE
fix: enable Velero CSI snapshots for Ceph

### DIFF
--- a/k3s-apps/rook-cluster.yaml
+++ b/k3s-apps/rook-cluster.yaml
@@ -231,19 +231,19 @@ spec:
             isDefault: true
             deletionPolicy: Delete
             annotations: { }
-            labels: { }
+            labels:
+              velero.io/csi-volumesnapshot-class: "true"
             # see https://rook.io/docs/rook/v1.10/Storage-Configuration/Ceph-CSI/ceph-csi-snapshot/#cephfs-snapshots for available configuration
             parameters: { }
 
-          # -- Settings for the block pool snapshot class
-          # @default -- See [RBD Snapshots](../Storage-Configuration/Ceph-CSI/ceph-csi-snapshot.md#rbd-snapshots)
           cephBlockPoolsVolumeSnapshotClass:
             enabled: true
             name: ceph-block
             isDefault: false
             deletionPolicy: Delete
             annotations: { }
-            labels: { }
+            labels:
+              velero.io/csi-volumesnapshot-class: "true"
             # see https://rook.io/docs/rook/v1.10/Storage-Configuration/Ceph-CSI/ceph-csi-snapshot/#rbd-snapshots for available configuration
             parameters: { }
 


### PR DESCRIPTION
Adds 'velero.io/csi-volumesnapshot-class: true' label to Ceph VolumeSnapshotClasses to enable Velero backups for volume-based PVCs (e.g. KubeVirt VMs).