### PR TITLE
fix(prometheus): disable KubeClientCertificateExpiration alert

### DIFF
--- a/k3s-apps/prometheus.yaml
+++ b/k3s-apps/prometheus.yaml
@@ -40,6 +40,7 @@ spec:
         defaultRules:
           rules:
             kubeProxy: false
+            kubeClientCertificateExpiration: false
         kubeProxy:
           enabled: false
         kubeEtcd:


### PR DESCRIPTION
## What
- disable the `KubeClientCertificateExpiration` default rule in kube-prometheus-stack

## Why
This alert is noisy in the homelab setup and not useful enough to keep as a Telegram-facing notification.

## Validation
- parsed `k3s-apps/prometheus.yaml` successfully with PyYAML
- confirmed the diff only disables this single default rule
