### PR TITLE
fix(alertmanager): drop KubeClientCertificateExpiration alerts

### DIFF
--- a/k3s-apps/prometheus.yaml
+++ b/k3s-apps/prometheus.yaml
@@ -133,7 +133,7 @@ spec:
               routes:
                 - receiver: 'null'
                   matchers:
-                    - alertname =~ "Watchdog|InfoInhibitor"
+                    - alertname =~ "Watchdog|InfoInhibitor|KubeClientCertificateExpiration"
             receivers:
               - name: 'null'
               - name: 'telegram-homelab'


### PR DESCRIPTION
## What
- route `KubeClientCertificateExpiration` alerts to the `null` receiver in Alertmanager

## Why
The previous attempt disabled `defaultRules.rules.kubeClientCertificateExpiration`, but the rule still exists in the live cluster after merge for kube-prometheus-stack 82.14.0.
This PR applies a reliable suppression at the Alertmanager routing layer so these alerts stop reaching Telegram.

## Validation
- confirmed `KubeClientCertificateExpiration` is still present in live `PrometheusRule` resources
- confirmed Argo CD `Application` values already include `kubeClientCertificateExpiration: false`
- parsed `k3s-apps/prometheus.yaml` successfully with PyYAML
