### PR TITLE
fix(prometheus): disable KubeClientCertificateExpiration correctly

### DIFF
--- a/k3s-apps/prometheus.yaml
+++ b/k3s-apps/prometheus.yaml
@@ -40,7 +40,8 @@ spec:
         defaultRules:
           rules:
             kubeProxy: false
-            kubeClientCertificateExpiration: false
+          disabled:
+            KubeClientCertificateExpiration: true
         kubeProxy:
           enabled: false
         kubeEtcd:


### PR DESCRIPTION
## What
- disable `KubeClientCertificateExpiration` using the chart's actual supported key: `defaultRules.disabled.KubeClientCertificateExpiration: true`

## Why
The previous config used:
- `defaultRules.rules.kubeClientCertificateExpiration: false`

That key does not control this rule in `kube-prometheus-stack` `82.14.0`.
The upstream template for `kubernetes-system-apiserver` checks:
- `.Values.defaultRules.disabled.KubeClientCertificateExpiration`

So the alert remained present in the live cluster even after merge.

## Validation
- verified live Argo CD application values were applied
- verified live `PrometheusRule` still contained `KubeClientCertificateExpiration`
- checked upstream chart template for `82.14.0` and confirmed the correct disable key
- parsed `k3s-apps/prometheus.yaml` successfully with PyYAML
