### PR TITLE
fix(openbao): use correct rolling update strategy key

### DIFF
--- a/k3s-apps/openbao.yaml
+++ b/k3s-apps/openbao.yaml
@@ -14,7 +14,7 @@ spec:
     helm:
       valuesObject:
         server:
-          updateStrategy: "RollingUpdate"
+          updateStrategyType: "RollingUpdate"
           podManagementPolicy: "Parallel"
           volumes:
             - name: seal-key


### PR DESCRIPTION
## What
- replace `server.updateStrategy` with the actual chart-supported key `server.updateStrategyType`
- keep OpenBao StatefulSet on `RollingUpdate` as intended

## Why
The repository and Argo CD application values already contained:
- `server.updateStrategy: RollingUpdate`

But the OpenBao chart template reads:
- `server.updateStrategyType`

As a result, the live StatefulSet still rendered with:
- `updateStrategy.type: OnDelete`

This caused OpenBao rollouts to require manual pod deletion and led to `KubeStatefulSetUpdateNotRolledOut` alerts.

## Validation
- confirmed live Argo CD application already had the wrong key
- confirmed upstream OpenBao chart template reads `server.updateStrategyType`
- confirmed live StatefulSet still used `OnDelete`
- parsed `k3s-apps/openbao.yaml` successfully with PyYAML
