### PR TITLE
fix(kubescape): increase storage and exclude noisy namespaces

### DIFF
--- a/k3s-apps/kubescape.yaml
+++ b/k3s-apps/kubescape.yaml
@@ -14,12 +14,15 @@ spec:
     helm:
       valuesObject:
         clusterName: homelab
+        excludeNamespaces: "kubescape,kube-system,kube-public,kube-node-lease,kubeconfig,gmp-system,gmp-public,velero,github-runner"
         capabilities:
           continuousScan: enable
           vulnerabilityScan: enable
           nodeScan: enable
         persistence:
           storageClass: "ceph-block"
+          size:
+            backingStorage: 25Gi
 
   ignoreDifferences:
     - group: ''


### PR DESCRIPTION
## What
- increase Kubescape backing storage from `5Gi` to `25Gi`
- exclude `velero` and `github-runner` namespaces from Kubescape scanning

## Why
Kubescape storage was nearly full (~99.7%) and the storage service was failing with:
- `no space left on device`
- repeated `EOF` / `unexpected EOF`
- large volumes of `containerprofile` objects

The noisiest contributors in logs were `velero` and `github-runner`, both of which generate many short-lived and high-churn objects that are low-value for this homelab setup.

This should:
- stop immediate disk pressure on the backing PVC
- reduce future growth from ephemeral backup/job workloads
- reduce CPU throttling caused by the storage service trying to process and clean up under disk exhaustion

## Validation
- confirmed current PVC `kubescape-storage` is 5Gi and ~99.68% full
- confirmed storage logs contain repeated `no space left on device`
- confirmed chart supports `persistence.size.backingStorage`
- confirmed chart supports `excludeNamespaces`
- parsed `k3s-apps/kubescape.yaml` successfully with PyYAML
