### PR TITLE
feat(trmnl): wire 17track key from OpenBao

### DIFF
--- a/k3s-apps/trmnl-cyberpunk.yaml
+++ b/k3s-apps/trmnl-cyberpunk.yaml
@@ -87,6 +87,10 @@ spec:
                   remoteRef:
                     key: trmnl-cyberpunk
                     property: actualbudget_encryption
+                - secretKey: SEVENTEENTRACK_KEY
+                  remoteRef:
+                    key: trmnl-cyberpunk
+                    property: seventeentrack_key
 
         ingress:
           enabled: true


### PR DESCRIPTION
## Summary
- extend the trmnl-cyberpunk ExternalSecret with 
- source the value from the existing  OpenBao path

## Notes
- this assumes  has been written to OpenBao
- application-side support is handled in the paired trmnl-cyberpunk PR