### PR TITLE
feat: expose suwayomi via cloudflare tunnel

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -99,6 +99,10 @@ locals {
       originRequest = {
         noTLSVerify = true
       }
+    }, {
+      short = "suwayomi"
+      hostname = "suwayomi.kirillorlov.pro"
+      service  = "http://suwayomi-server.nextcloud.svc.cluster.local:4568"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `suwayomi.kirillorlov.pro` to the Cloudflare tunnel ingress list
- Routes traffic to the in-cluster Suwayomi service in `nextcloud`

## Verification
- `git diff --check origin/master...HEAD`
- HCL parse check with `python-hcl2`

## Notes
- No local `terraform` binary is installed on this machine, so full `fmt/validate` couldn't be run here.
- CI should own the real Terraform validation/deploy path.
