### PR TITLE
Add Headlamp Kubernetes dashboard with Zitadel OIDC end-to-end auth

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -143,6 +143,14 @@
             export TF_VAR_quay_username=$(tfvar quay username)
             export TF_VAR_quay_token=$(tfvar quay token)
 
+            # kube-apiserver OIDC (Zitadel) trusts tokens minted for the Headlamp
+            # OIDC client, so its client_id is the apiserver's oidc-client-id.
+            # talhelper runs envsubst over talos/talconfig.yaml against the process
+            # environment, so exporting it here lets ${HEADLAMP_OIDC_CLIENT_ID}
+            # resolve at `task talos:genconfig`. Written to OpenBao by
+            # terraform/zitadel.tf, so `tofu apply` must run first.
+            export HEADLAMP_OIDC_CLIENT_ID=$(tfvar zitadel/headlamp-credentials client_id)
+
             # Fetch the age key used for all SOPS (Talos configs + terraform/tfstate.sops).
             # Safe for local dev (falls back to empty if bao not logged in).
             export SOPS_AGE_KEY=$(bao kv get -field=age_key secret/talos/config 2>/dev/null || true)

--- a/flake.nix
+++ b/flake.nix
@@ -146,10 +146,21 @@
             # kube-apiserver OIDC (Zitadel) trusts tokens minted for the Headlamp
             # OIDC client, so its client_id is the apiserver's oidc-client-id.
             # talhelper runs envsubst over talos/talconfig.yaml against the process
-            # environment, so exporting it here lets ${HEADLAMP_OIDC_CLIENT_ID}
-            # resolve at `task talos:genconfig`. Written to OpenBao by
-            # terraform/zitadel.tf, so `tofu apply` must run first.
+            # environment, so exporting HEADLAMP_OIDC_CLIENT_ID here lets its
+            # placeholder in talconfig.yaml resolve at `task talos:genconfig`.
+            # (Written as a bare name, not a $-brace form: this shellHook is a Nix
+            # indented string, where a dollar-brace is antiquotation even inside a
+            # shell comment.) Written to OpenBao by
+            # terraform/zitadel.tf (`tofu apply`), which needs a healthy cluster
+            # and therefore runs AFTER `task talos:apply` in the CI pipeline — so
+            # on the very first rollout the secret doesn't exist yet. Fall back to
+            # a non-empty placeholder in that window: an empty oidc-client-id with
+            # oidc-issuer-url set makes the API server refuse to start, whereas a
+            # bogus-but-non-empty audience just leaves OIDC inert (real tokens
+            # rejected, PKI/ServiceAccount auth unaffected) until the next apply
+            # picks up the real value.
             export HEADLAMP_OIDC_CLIENT_ID=$(tfvar zitadel/headlamp-credentials client_id)
+            export HEADLAMP_OIDC_CLIENT_ID=''${HEADLAMP_OIDC_CLIENT_ID:-headlamp-oidc-pending}
 
             # Fetch the age key used for all SOPS (Talos configs + terraform/tfstate.sops).
             # Safe for local dev (falls back to empty if bao not logged in).

--- a/k3s-apps/headlamp.yaml
+++ b/k3s-apps/headlamp.yaml
@@ -1,0 +1,76 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: headlamp
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  # Multi-source: the upstream Helm chart plus a git source that carries the
+  # OIDC ExternalSecret (k3s-apps/headlamp/externalsecret.yaml). Same shape as
+  # the kubescape app.
+  sources:
+    - repoURL: https://kubernetes-sigs.github.io/headlamp
+      chart: headlamp
+      targetRevision: 0.44.0
+      helm:
+        valuesObject:
+          fullnameOverride: headlamp
+          # End-to-end OIDC: every Kubernetes API call Headlamp makes carries the
+          # logged-in user's Zitadel id_token, which the kube-apiserver validates
+          # via its oidc-* flags (talos/talconfig.yaml) and authorizes against the
+          # per-user RBAC in k3s-objects/oidc-admin-rbac.yaml. Headlamp's own
+          # ServiceAccount therefore needs NO cluster access — do not bind it to
+          # cluster-admin (that would be the shared-credential model we chose
+          # against).
+          clusterRoleBinding:
+            create: false
+          config:
+            oidc:
+              # Credentials come from the ExternalSecret below, not a chart-managed
+              # Secret. hasScopes=true because that Secret carries OIDC_SCOPES.
+              secret:
+                create: false
+              externalSecret:
+                enabled: true
+                name: headlamp-oidc
+                hasScopes: true
+          ingress:
+            enabled: true
+            ingressClassName: traefik
+            # Internal-only (no kirillorlov.pro/expose label): a cluster-admin
+            # dashboard must never reach the public Hetzner edge. LAN + tailnet
+            # only, same posture as the other admin UIs here.
+            annotations:
+              cert-manager.io/cluster-issuer: acme-issuer
+
+              gethomepage.dev/enabled: "true"
+              gethomepage.dev/href: "https://headlamp.kirillorlov.pro"
+              gethomepage.dev/group: Cluster Management
+              gethomepage.dev/name: Headlamp
+              gethomepage.dev/icon: "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/refs/heads/main/png/headlamp.png"
+              gethomepage.dev/description: Kubernetes web UI
+              gethomepage.dev/pod-selector: "app.kubernetes.io/name=headlamp"
+            hosts:
+              - host: headlamp.kirillorlov.pro
+                paths:
+                  - path: /
+                    type: Prefix
+            tls:
+              - secretName: headlamp-tls
+                hosts:
+                  - headlamp.kirillorlov.pro
+    - repoURL: https://github.com/DiverOfDark/homelab.git
+      targetRevision: HEAD
+      path: k3s-apps/headlamp
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: headlamp
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - RespectIgnoreDifferences=true

--- a/k3s-apps/headlamp/externalsecret.yaml
+++ b/k3s-apps/headlamp/externalsecret.yaml
@@ -1,0 +1,39 @@
+# OIDC client credentials for Headlamp's login flow. The Zitadel "Headlamp"
+# OIDC app is managed in terraform/zitadel.tf; its client_id/client_secret are
+# written to OpenBao at secret/zitadel/headlamp-credentials by the
+# zitadel_credentials loop. Headlamp consumes these as environment variables
+# (config.oidc.externalSecret in k3s-apps/headlamp.yaml renders an `envFrom`
+# secretRef to this Secret).
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: headlamp-oidc
+  namespace: headlamp
+spec:
+  secretStoreRef:
+    name: openbao-store
+    kind: ClusterSecretStore
+  refreshInterval: "1h"
+  target:
+    name: headlamp-oidc
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      type: Opaque
+      data:
+        OIDC_CLIENT_ID: "{{ .client_id }}"
+        OIDC_CLIENT_SECRET: "{{ .client_secret }}"
+        OIDC_ISSUER_URL: "https://auth.kirillorlov.pro"
+        # `openid` is always added by Headlamp; `email` is required so the
+        # id_token carries the claim the kube-apiserver maps to a user
+        # (oidc-username-claim=email in talos/talconfig.yaml).
+        OIDC_SCOPES: "email,profile"
+  data:
+    - secretKey: client_id
+      remoteRef:
+        key: zitadel/headlamp-credentials
+        property: client_id
+    - secretKey: client_secret
+      remoteRef:
+        key: zitadel/headlamp-credentials
+        property: client_secret

--- a/k3s-apps/headlamp/externalsecret.yaml
+++ b/k3s-apps/headlamp/externalsecret.yaml
@@ -24,10 +24,10 @@ spec:
         OIDC_CLIENT_ID: "{{ .client_id }}"
         OIDC_CLIENT_SECRET: "{{ .client_secret }}"
         OIDC_ISSUER_URL: "https://auth.kirillorlov.pro"
-        # `openid` is always added by Headlamp; `email` is required so the
-        # id_token carries the claim the kube-apiserver maps to a user
+        # `openid` is required for the OIDC id_token; `email` is required so
+        # the id_token carries the claim the kube-apiserver maps to a user
         # (oidc-username-claim=email in talos/talconfig.yaml).
-        OIDC_SCOPES: "email,profile"
+        OIDC_SCOPES: "openid email profile"
   data:
     - secretKey: client_id
       remoteRef:

--- a/k3s-objects/oidc-admin-rbac.yaml
+++ b/k3s-objects/oidc-admin-rbac.yaml
@@ -1,0 +1,23 @@
+# Grants the human operator — authenticated via Zitadel OIDC and mapped by the
+# kube-apiserver oidc-* flags in talos/talconfig.yaml — full cluster access.
+#
+# The API server runs with oidc-username-claim=email and
+# oidc-username-prefix="oidc:", so a Zitadel login for diverofdark@gmail.com
+# arrives at the API server as the user "oidc:diverofdark@gmail.com". This
+# binding is what makes Headlamp's end-to-end OIDC login able to actually
+# see/manage the cluster: Headlamp forwards the user's id_token, the API server
+# authenticates it and authorizes every request against this ClusterRoleBinding.
+# A kubectl context configured with the same Zitadel issuer/client resolves to
+# the same identity and reuses this binding.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: oidc-cluster-admin
+subjects:
+  - apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: "oidc:diverofdark@gmail.com"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -418,6 +418,24 @@ controlPlane:
     - |-
       cluster:
         apiServer:
+          # OIDC (Zitadel) end-to-end auth. Headlamp (and any kubectl context set
+          # up the same way) logs the user in against Zitadel and forwards the
+          # resulting id_token to the API server; these flags make the API server
+          # validate it and map it to a user for RBAC (see
+          # k3s-objects/oidc-admin-rbac.yaml). oidc-client-id is the Headlamp
+          # Zitadel client_id, injected via envsubst from HEADLAMP_OIDC_CLIENT_ID
+          # (exported by flake.nix from OpenBao) — so `tofu apply` (which creates
+          # the Zitadel app) must precede regenerating configs, and genconfig must
+          # run inside the nix devshell with `bao` logged in, or the value renders
+          # empty and the API server refuses to start with an issuer set.
+          # Additive: existing PKI / ServiceAccount auth is untouched, and if
+          # Zitadel is unreachable only OIDC logins fail (JWKS fetch is retried,
+          # startup is not blocked on k8s 1.36).
+          extraArgs:
+            oidc-issuer-url: https://auth.kirillorlov.pro
+            oidc-client-id: ${HEADLAMP_OIDC_CLIENT_ID}
+            oidc-username-claim: email
+            oidc-username-prefix: "oidc:"
           disablePodSecurityPolicy: true
           admissionControl:
             - name: PodSecurity

--- a/terraform/zitadel.tf
+++ b/terraform/zitadel.tf
@@ -308,6 +308,23 @@ resource "zitadel_application_oidc" "headplane" {
   id_token_userinfo_assertion = true
 }
 
+resource "zitadel_application_oidc" "headlamp" {
+  org_id                      = var.zitadel_org_id
+  project_id                  = zitadel_project.homelab.id
+  name                        = "Headlamp"
+  redirect_uris               = ["https://headlamp.kirillorlov.pro/oidc-callback"]
+  post_logout_redirect_uris   = ["https://headlamp.kirillorlov.pro"]
+  response_types              = ["OIDC_RESPONSE_TYPE_CODE"]
+  grant_types                 = ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE"]
+  app_type                    = "OIDC_APP_TYPE_WEB"
+  auth_method_type            = "OIDC_AUTH_METHOD_TYPE_BASIC"
+  version                     = "OIDC_VERSION_1_0"
+  access_token_type           = "OIDC_TOKEN_TYPE_JWT"
+  access_token_role_assertion = true
+  id_token_role_assertion     = true
+  id_token_userinfo_assertion = true
+}
+
 resource "zitadel_application_saml" "ceph_dashboard" {
   org_id       = var.zitadel_org_id
   project_id   = zitadel_project.homelab.id
@@ -387,6 +404,11 @@ locals {
     headscale = zitadel_application_oidc.headscale
     # Consumed in-cluster by ESO (k3s-userapps/headplane/externalsecret.yaml)
     headplane = zitadel_application_oidc.headplane
+    # Consumed in-cluster by ESO (k3s-apps/headlamp/externalsecret.yaml). The
+    # client_id is ALSO fed to the kube-apiserver as its oidc-client-id (via
+    # HEADLAMP_OIDC_CLIENT_ID exported from flake.nix -> talos/talconfig.yaml),
+    # so `tofu apply` must run before regenerating Talos configs.
+    headlamp = zitadel_application_oidc.headlamp
   }
 }
 


### PR DESCRIPTION
Installs [headlamp.dev](https://headlamp.dev) as a cluster dashboard, authenticated **end-to-end via the existing Zitadel IdP** rather than a shared cluster-admin ServiceAccount. Each user logs into Zitadel; Headlamp forwards their id_token to the API server, which validates it and authorizes every request against real per-user RBAC.

## Changes

| File | Role |
|------|------|
| `terraform/zitadel.tf` | New `Headlamp` OIDC app (`redirect_uris: https://headlamp.kirillorlov.pro/oidc-callback`); registered in the credentials loop so client_id/secret land in OpenBao at `zitadel/headlamp-credentials`. |
| `talos/talconfig.yaml` | kube-apiserver `oidc-*` flags (`oidc-issuer-url=https://auth.kirillorlov.pro`, `oidc-username-claim=email`, `oidc-username-prefix="oidc:"`). Additive — existing PKI/ServiceAccount auth untouched; if Zitadel is unreachable only OIDC logins fail (JWKS fetch is retried, startup not blocked on k8s 1.36). |
| `flake.nix` | Exports `HEADLAMP_OIDC_CLIENT_ID` from OpenBao so talhelper's envsubst fills the API server's `oidc-client-id`. |
| `k3s-objects/oidc-admin-rbac.yaml` | `ClusterRoleBinding` mapping `oidc:diverofdark@gmail.com` → `cluster-admin`. |
| `k3s-apps/headlamp.yaml` | ArgoCD Application: Helm chart `0.44.0` + git multi-source, internal-only ingress (no `expose` label), `clusterRoleBinding.create: false` (least privilege — the SA gets no cluster access). |
| `k3s-apps/headlamp/externalsecret.yaml` | ExternalSecret rendering `OIDC_CLIENT_ID/SECRET/ISSUER_URL/SCOPES` env from OpenBao. |

## Apply order (one-time bootstrap)

The API server needs Headlamp's Zitadel client_id, which Terraform generates — so order matters:

1. `cd terraform && tofu apply` — creates the Zitadel app, writes creds to OpenBao.
2. Re-enter the nix devshell (picks up `HEADLAMP_OIDC_CLIENT_ID`) with `bao` logged in.
3. `task talos:apply` — rolls out the API server OIDC flags. If step 1 hasn't run, the client_id renders empty and the API server refuses to start with an issuer set.
4. Merge — ArgoCD syncs the app, ExternalSecret, and RBAC binding.

Headlamp then serves at `https://headlamp.kirillorlov.pro` (LAN/tailnet only); "Sign In" redirects to Zitadel.

## Notes

- **Access is scoped to `diverofdark@gmail.com` only.** Additional operators need their own binding (Zitadel emits project roles rather than a plain `groups` claim, so a per-user binding was chosen over a group claim).
- Renovate's ArgoCD manager tracks the `0.44.0` chart automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CLf4zBKaCiaEtUx2AQQkXc)_