### PR TITLE
Enable Headlamp plugin manager with 8 pinned plugins

### DIFF
--- a/k3s-apps/headlamp.yaml
+++ b/k3s-apps/headlamp.yaml
@@ -36,6 +36,76 @@ spec:
                 enabled: true
                 name: headlamp-oidc
                 hasScopes: true
+            # The pluginsManager sidecar installs into /headlamp/plugins AFTER the
+            # main container has already scanned it at startup, so without this the
+            # plugins only appear on the next restart. (Unrelated to the bundled
+            # Prometheus plugin, which lives in /headlamp/static-plugins.)
+            watchPlugins: true
+          # Headlamp's in-app "Plugin Catalog" is desktop-only — it installs via
+          # PluginManager, a wrapper around Electron's window.desktopApi, which
+          # doesn't exist in a browser (and a browser could not write into this
+          # pod's filesystem anyway). The in-cluster equivalent is this sidecar:
+          # it runs `pluginctl install --config plugin.yml --watch` against a
+          # shared emptyDir, so the plugin set is declarative and lives in git.
+          #
+          # Every version here is pinned deliberately. The sidecar pulls pluginctl
+          # from the public npm registry and the plugin tarballs from ArtifactHub —
+          # neither goes through Harbor — and this is a cluster-admin dashboard, so
+          # floating tags would mean unreviewed third-party JS landing in it on any
+          # pod restart. Renovate has no ArtifactHub-plugin manager; bump by hand.
+          pluginsManager:
+            enabled: true
+            version: "0.1.1"
+            # Downloads + unpacks 8 tarballs at startup, then idles on --watch.
+            resources:
+              requests:
+                cpu: 50m
+                memory: 192Mi
+              limits:
+                cpu: "1"
+                memory: 1Gi
+            configContent: |
+              plugins:
+                # Kubescape is already running here but had no UI: compliance
+                # scores, CVEs, network policies, runtime threats.
+                - name: headlamp_kubescape
+                  source: https://artifacthub.io/packages/headlamp/kubescape-headlamp-plugin/headlamp_kubescape
+                  version: 0.11.2
+                # CephCluster health, pool status and CSI driver views — the part
+                # of this cluster most likely to need a look at 3am.
+                - name: headlamp-rook-plugin
+                  source: https://artifacthub.io/packages/headlamp/headlamp-rook/headlamp-rook-plugin
+                  version: 1.0.2
+                # Certificate/Issuer/Order/Challenge status. Every ingress here is
+                # issued by acme-issuer, so this is the fast path to "why is this
+                # cert not renewing".
+                - name: headlamp_cert-manager
+                  source: https://artifacthub.io/packages/headlamp/headlamp-plugins/headlamp_cert-manager
+                  version: 0.1.1
+                # Policies plus the wgpolicyk8s.io PolicyReports they produce.
+                - name: headlamp_kyverno
+                  source: https://artifacthub.io/packages/headlamp/headlamp-plugins/headlamp_kyverno
+                  version: 0.1.0
+                # App health/sync inline — everything in this cluster is ArgoCD-managed.
+                - name: headlamp-argocd
+                  source: https://artifacthub.io/packages/headlamp/headlamp-argocd/headlamp-argocd
+                  version: 0.1.3
+                - name: headlamp-metallb-plugin
+                  source: https://artifacthub.io/packages/headlamp/headlamp-metallb-plugin/headlamp-metallb-plugin
+                  version: 0.5.1
+                # Both of the following are stale upstream (ESO plugin untouched
+                # since 2025-07 and still beta; kubevirt since 2025-03). Kept
+                # because both operators are core here, but drop them rather than
+                # debug them if they break on a Headlamp bump.
+                - name: external-secrets-operator
+                  source: https://artifacthub.io/packages/headlamp/external-secrets-operator-headlamp-plugin/external-secrets-operator
+                  version: 0.1.0-beta7
+                - name: headlamp_kubevirt
+                  source: https://artifacthub.io/packages/headlamp/headlamp-kubevirt/headlamp_kubevirt
+                  version: 0.2.2
+              installOptions:
+                parallel: true
+                maxConcurrent: 3
           ingress:
             enabled: true
             ingressClassName: traefik


### PR DESCRIPTION
## Why

Headlamp's in-app **Plugin Catalog cannot be enabled in-cluster** — it's desktop-only by design, not configuration. Its install path goes through `PluginManager`, documented in headlamp core as *"a wrapper class for initiating calls to Electron via desktopApi"*. In a browser `window.desktopApi` is undefined, and a click in the browser has no way to write into the pod's filesystem regardless. It isn't even published on ArtifactHub — it ships inside the desktop app.

The chart's `pluginsManager` sidecar is the in-cluster equivalent, and a better fit for this repo: it runs `pluginctl install --config plugin.yml --watch` against a shared `emptyDir`, so the plugin set stays declarative and in git.

## What

Selected by matching all 96 Headlamp packages on ArtifactHub against what this cluster actually runs (page 2 of that listing is almost entirely junk mirrors under `test-123`/`kyverno011` — ignored).

| Plugin | Version | Why |
|---|---|---|
| `headlamp_kubescape` | 0.11.2 | Official Kubescape plugin. Kubescape was running here with no UI at all — compliance, CVEs, network policies, runtime threats. All 5 kubescape APIServices verified `Available=True`, so it'll have data. |
| `headlamp-rook-plugin` | 1.0.2 | CephCluster health, pool status, CSI driver views. |
| `headlamp_cert-manager` | 0.1.1 | Certificate/Issuer/Order/Challenge status; every ingress here is `acme-issuer`. |
| `headlamp_kyverno` | 0.1.0 | Policies + the `wgpolicyk8s.io` PolicyReports they produce. |
| `headlamp-argocd` | 0.1.3 | Application health/sync inline. |
| `headlamp-metallb-plugin` | 0.5.1 | Marginal, but actively maintained and cheap. |
| `external-secrets-operator` | 0.1.0-beta7 | ⚠️ Beta, untouched upstream since 2025-07. |
| `headlamp_kubevirt` | 0.2.2 | ⚠️ Stale upstream since 2025-03. |

The last two are kept only because both operators are core here; the comment in the file says to drop them rather than debug them if a Headlamp bump breaks them.

**Deliberately skipped:** `helm-plugin` (reads Helm release Secrets, which ArgoCD never creates — would show nothing), `click-ops` (point-and-click ServiceAccount/RBAC creation = exactly the drift this repo gets bitten by, with no `selfHeal`), `beacon` (Renovate already tracks versions), `kube-vip` (the VIP is Talos `Layer2VIPConfig`), plus flux/crossplane/istio/karpenter/keda/knative/strimzi/gatekeeper/sealed-secrets/OLM/trivy/polaris/opencost — backends not installed. Nothing exists for Velero, CNPG, Traefik, Cilium or VictoriaMetrics.

## Two things worth reviewing

- **`config.watchPlugins: true` is load-bearing.** The sidecar populates `/headlamp/plugins` *after* the main container has already scanned it, so without this the plugins only appear on the next restart. The bundled Prometheus plugin is unaffected — separate path (`/headlamp/static-plugins`), confirmed empty vs. populated in the running image.
- **Supply chain.** The sidecar pulls `pluginctl` from the public npm registry and the plugin tarballs from ArtifactHub — neither through Harbor — into a cluster-admin dashboard. Everything is pinned (`pluginctl` to 0.1.1, its only published release) so a restart can't pull unreviewed JS. Renovate has no ArtifactHub-plugin manager, so these need manual bumps.

## Verification

- `helm template` with these values renders cleanly: `headlamp-plugin` sidecar present, shared `plugins-dir` emptyDir mounted into both containers, `-watch-plugins-changes` on the main container, sidecar inheriting the chart's `runAsNonRoot`/uid 100 context.
- Generated `plugin.yml` validated against pluginctl 0.1.1's actual AJV schema (name/source/version patterns transcribed from source) — 8/8 pass, no duplicate names.
- All 8 package+version pairs confirmed to exist on ArtifactHub with resolvable archive URLs.

Not yet observed running in-cluster — ArgoCD will roll it on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)