### PR TITLE
Add trade-republic-rest-api

### DIFF
--- a/k3s-apps/trade-republic-rest-api.yaml
+++ b/k3s-apps/trade-republic-rest-api.yaml
@@ -1,0 +1,91 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: trade-republic-rest-api
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    # Pull the helm chart straight from the source repo's master branch.
+    # The chart lives at helm/trade-republic-rest-api and moves in lockstep
+    # with the Rust code that produces the image, so chart-version drift and
+    # image-version drift can't diverge.
+    repoURL: https://github.com/DiverOfDark/trade-republic-rest-api.git
+    targetRevision: master
+    path: helm/trade-republic-rest-api
+    helm:
+      # Image tag is set via --set so Argo's build-environment substitution
+      # kicks in (interpolation does NOT work inside valuesObject). CI
+      # publishes ghcr.io/diverofdark/trade-republic-rest-api:sha-<7-char-sha>
+      # for every commit, so this resolves to the exact image built from the
+      # commit Argo is currently syncing.
+      # https://argo-cd.readthedocs.io/en/stable/user-guide/build-environment/
+      parameters:
+        - name: image.tag
+          value: sha-$ARGOCD_APP_REVISION_SHORT
+      valuesObject:
+        # gethomepage's pod-selector annotation expects this exact label.
+        podLabels:
+          app.kubernetes.io/pod: trade-republic-rest-api
+
+        # Holds cookies.json — the Trade Republic session. It is the whole
+        # reason a restart doesn't need a human: without it, every pod restart
+        # means port-forwarding in and running the login flow again. Tiny, but
+        # 1Gi is the smallest ceph-block volume worth asking for.
+        persistence:
+          enabled: true
+          size: 1Gi
+          storageClassName: ceph-block
+
+        # No credentials in the cluster. The phone number and PIN are posted
+        # once to /api/v1/auth/login; the resulting session lives on the PVC
+        # above and the pod refreshes it every 240s by itself. Nothing to add
+        # to OpenBao, and the PIN never sits in a Secret.
+        credentials:
+          enabled: false
+
+        ingress:
+          enabled: true
+          className: traefik
+          host: traderepublic.kirillorlov.pro
+          # Internal only: no `kirillorlov.pro/expose: external` annotation, so
+          # kyverno's generate-external-ingress policy does NOT clone this onto
+          # traefik-external. This must stay off the Hetzner edge.
+          #
+          # The chart normally refuses to render an Ingress without a bearer
+          # token, because an open one publishes the whole portfolio and
+          # transaction history. Acknowledged deliberately here: the service is
+          # reachable from the LAN only. To require a token instead, drop this
+          # flag, set apiToken.enabled=true, and add a `token` entry to OpenBao
+          # wired up through additionalObjects.
+          allowUnauthenticated: true
+          annotations:
+            cert-manager.io/cluster-issuer: acme-issuer
+            # No buffering or timeout annotations: /api/v1/instruments/{isin}/
+            # ticker/stream is an unending SSE response, and Traefik streams
+            # responses without buffering and has no default idle timeout on
+            # them — unlike nginx, which would need both.
+            gethomepage.dev/enabled: "true"
+            gethomepage.dev/href: "https://traderepublic.kirillorlov.pro/api/docs"
+            gethomepage.dev/group: Apps
+            gethomepage.dev/name: Trade Republic
+            gethomepage.dev/icon: mdi-chart-line
+            gethomepage.dev/pod-selector: "app.kubernetes.io/pod=trade-republic-rest-api"
+            gethomepage.dev/description: "Unofficial read-only Trade Republic API"
+          tls:
+            - hosts:
+                - traderepublic.kirillorlov.pro
+              secretName: trade-republic-rest-api-tls
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: trade-republic
+  syncPolicy:
+    automated:
+      prune: true
+    syncOptions:
+      - CreateNamespace=true
+      - ServerSideApply=true
+      - RespectIgnoreDifferences=true


### PR DESCRIPTION
Installs [trade-republic-rest-api](https://github.com/DiverOfDark/trade-republic-rest-api) — an unofficial, read-only REST façade over Trade Republic's private websocket API, so the portfolio is readable from a dashboard, a notebook or a cron job.

One new file, `k3s-apps/trade-republic-rest-api.yaml`. `meta-app` auto-discovers it, so that is the whole install.

## Shape

Same as picweight/phos/trackhound: chart pulled from the source repo's `master` at `helm/trade-republic-rest-api`, image pinned via `image.tag=sha-$ARGOCD_APP_REVISION_SHORT` so the image always matches the commit Argo is syncing.

Verified rather than assumed — the `valuesObject` was extracted and rendered against the real chart:

- renders PVC + Service + Deployment + Ingress, and **no Secret** (the chart never generates one, and now refers to none at all unless you enable the API token);
- image resolves to `ghcr.io/diverofdark/trade-republic-rest-api:sha-<sha>`, anonymously pullable from GHCR, so no imagePullSecret is needed;
- source-repo CI is green — fmt, clippy `-D warnings`, 49 tests, helm lint/template across four value files, and the image build which runs `cargo test --release` inside itself.

## Two choices worth your review

**Internal ingress, unauthenticated.** No `kirillorlov.pro/expose: external`, so kyverno does not clone it onto the Hetzner edge — this must stay on the LAN. The chart normally *refuses* to render an Ingress without a bearer token, because an open one publishes the entire portfolio and transaction history; `ingress.allowUnauthenticated: true` acknowledges that deliberately. Note this also means anyone on the LAN can reach the sign-in page. To tighten it: drop that flag, set `apiToken.enabled=true`, and add a `token` entry to OpenBao wired through `additionalObjects` — the panel then prompts for the token.

**No credentials anywhere in the cluster.** There is no chart setting for the Trade Republic phone number and PIN, because upstream removed `TR_PHONE_NUMBER`/`TR_PIN` entirely: they are typed into the sign-in page, forwarded to Trade Republic, and dropped. A PIN in a pod's environment would show up in `kubectl describe`, in core dumps and in whatever ships our cluster logs.

## After merge — one manual step, once

A Trade Republic login needs a human for the second factor. After the first sync, open

    https://traderepublic.kirillorlov.pro/

and sign in: phone number and PIN, then either confirm in the Trade Republic app or enter an authenticator code, depending on what the account uses. The page then shows the session status and the keep-alive counting down to the next refresh.

That is the only time it is needed. The pod refreshes the session every 240s and persists the cookie to the PVC, so restarts and redeploys resume instead of re-authenticating. Until then `/healthz` reports `session: logged_out` and data routes answer 401 — deliberately, `/healthz` still returns `ok`, because a pod that failed liveness over a login it cannot perform would restart forever.

## Notes

- Read-only by construction: the service can only build non-mutating subscription payloads. `rawSubscribeEnabled` (which would forward arbitrary payloads, and TR takes orders through the same verb as quotes) is left off.
- Unofficial API: undocumented, may change without notice, and using it may conflict with Trade Republic's ToS. If logins ever start failing on a header/version complaint, `tradeRepublic.appVersion` overrides the pinned web build number without a rebuild.
- Homelab CI validates `talos/` and `terraform/` only, so this change is outside its scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nvE1sxaToLTVdrPk5E7ur